### PR TITLE
strsplit.m updates

### DIFF
--- a/DataFrame/Contents.m
+++ b/DataFrame/Contents.m
@@ -24,7 +24,7 @@
 %   cell2delim    - concatenate a cell array of strings into a delimited char array
 %   conv2str      - converts any (non-structure) input to a single string,
 %   makevert      - make any dimensional matrix or comma separated list into a column vector
-%   strsplit      - split a string into a cell array based on a single character delimiter
+%   strsplitdf    - split a string into a cell array based on a single character delimiter
 %   uniquenotmiss - find the unique values of a (cell) array (ignore NaN and '')
 %
 % Useful functions

--- a/DataFrame/DFread.m
+++ b/DataFrame/DFread.m
@@ -59,7 +59,7 @@ function [Data rawData Err origHeader] = DFread(filename,filedir,readLength, ...
 %     how many lines from the file will be used to determine the format of
 %     each column.
 % 
-%     DFread depends on DFverify, strsplit
+%     DFread depends on DFverify, strsplitdf
 %     Broad Institute
 %     Hy Carrinski
 %
@@ -465,7 +465,7 @@ function [header origHeader]  = makeheader(fid,readLength,numCommLines,robustDel
                 'whitespace', '','headerlines',numCommLines);
     for i = 1:numel(linedata{1})
         if not(isempty(linedata{1}{i}))
-            colsPerLine(i) = numel(strsplit(robustDelim, linedata{1}{i}));
+            colsPerLine(i) = numel(strsplitdf(robustDelim, linedata{1}{i}));
         end
     end
     numCols  = max(colsPerLine);
@@ -494,7 +494,7 @@ function rawData = lineread(fid, formats, numFields, numCommLines,robustDelim,ma
     rawArray(:) = {''};
     for i = 1:numel(linedata{1})
         if not(isempty(linedata{1}{i}))
-            oneLine = strsplit(robustDelim, linedata{1}{i}); % good solution
+            oneLine = strsplitdf(robustDelim, linedata{1}{i}); % good solution
             % textscan can drop trailing tab
             % truncates lines possessing more  elements than file's columns
             if not(isempty(oneLine))
@@ -565,7 +565,7 @@ function filelength = getfilelength(fid,filepath,maxLines)
     frewind(fid);
     %else
     %    [wcOkay unixNumRowsStr] = unix(['wc -l ' filepath]);
-    %    filelength              = strsplit(' ',unixNumRowsStr);
+    %    filelength              = strsplitdf(' ',unixNumRowsStr);
     %    if numel(filelength) > 1 && (wcOkay == 0)
     %        filelength = str2double(filelength(1));
     %    else

--- a/DataFrame/DFunmerge.m
+++ b/DataFrame/DFunmerge.m
@@ -17,7 +17,7 @@ function S = DFunmerge(S,fields,delim)
 %----------------------------------------------------------------
 %     Hy Carrinski
 %     Broad Institute
-%     Depends on enumitems.m
+%     Depends on enumitems.m, strsplitdf.m
 
 if nargin < 2 || not(isstruct(S)) || not( iscellstr(fields) || ischar(fields) )
     error('ccbr:BadInput','Please check inputs for DFunmerge');
@@ -50,7 +50,7 @@ end
 
 parsedStr = cell(numRows,numel(fields));
 for i = 1:numel(fields)
-    parsedStr(:,i)  = cellfun(@(x) strsplit(delim,x), ...
+    parsedStr(:,i)  = cellfun(@(x) strsplitdf(delim,x), ...
                       S.(fields{i}),'UniformOutput',false);
 end
 

--- a/DataFrame/utility/strsplitdf.m
+++ b/DataFrame/utility/strsplitdf.m
@@ -1,8 +1,8 @@
-function c = strsplit(d,s)
-% STRSPLIT
+function c = strsplitdf(d,s)
+% STRSPLITDF
 %          split a string into a cell array based on a single character delimiter
 %
-%    c = strsplit(d,s)
+%    c = strsplitdf(d,s)
 %
 % parameters
 %----------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ other column.
    * cell2delim    - concatenate a cell array of strings into a delimited char array
    * conv2str      - converts any (non-structure) input to a single string,
    * makevert      - make any dimensional matrix or comma separated list into a column vector
-   * strsplit      - split a string into a cell array based on a single character delimiter
+   * strsplitdf    - split a string into a cell array based on a single character delimiter
    * uniquenotmiss - find the unique values of a (cell) array (ignore NaN and '')
 
 #### Useful functions


### PR DESCRIPTION
The script strsplit.m was updated to strsplitdf.m for compatibility with MATLAB versions 2013a-2019a. Contents.m, DFread.m, and DFunmerge.m were updated due to their dependency on strsplit.m, and all other functions were systematically checked for occurrences of 'strsplit.'

